### PR TITLE
[bugfix] validate pkg.conf(5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ script:
   # See if the repo is private
   - if curl --silent --output /dev/null --dump-header - "https://github.com/${TRAVIS_REPO_SLUG}" | grep "Status:[[:space:]]*404"; then touch .private_repo; fi
 
+  # Download depended roles
+  - if [ -f requirements.yml ]; then ansible-galaxy install -r requirements.yml -p extra_roles; fi
+
   # Basic role syntax check
   #
   # If it is a private repo, it _usually_ has secret information, or encrypted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     src: repo.conf.j2
     dest: "{{ freebsd_repos_dir }}/{{ freebsd_repos_name }}.conf"
     mode: 0644
-    validate: pkg -vv --config %s | grep -E '^[[:space:]]+reallyenglish:[[:space:]]+{'
+    validate: pkg -vv --config %s | grep -E '^[[:space:]]+{{ freebsd_repos_name }}:[[:space:]]+{'
 
 - name: Disable default repo
   # XXX disable the default repo last only when other repo is validated and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,26 @@
     state: directory
     mode: 0755
 
+- assert:
+    msg: "invalid URL scheme found in freebsd_repos_url, use one that fetch(3) supports, pkg+http, or pkg+https: `{{ freebsd_repos_url }}`"
+    that:
+      - freebsd_repos_url | match("(?:https?|ftp|file|pkg\+https?):\/\/")
+
+- assert:
+    msg: "freebsd_repos_mirror_type must be one of HTTP, NONE, or SRV: `{{ freebsd_repos_mirror_type }}`"
+    that:
+      - freebsd_repos_mirror_type | upper | match("(?:HTTP|NONE|SRV)")
+
+- assert:
+    msg: "freebsd_repos_mirror_signature_type must be one of NONE, PUBKEY, or FINGERPRINTS: `{{ freebsd_repos_mirror_signature_type }}`"
+    that:
+      - freebsd_repos_mirror_signature_type | upper | match("(?:NONE|PUBKEY|FINGERPRINTS)")
+
+- assert:
+    msg: "freebsd_repos_priority must be integer: `{{ freebsd_repos_priority }}`"
+    that:
+      - freebsd_repos_priority is number
+
 - name: Disable default repo
   template:
     src: FreeBSD.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,35 +7,19 @@
     state: directory
     mode: 0755
 
-- assert:
-    msg: "invalid URL scheme found in freebsd_repos_url, use one that fetch(3) supports, pkg+http, or pkg+https: `{{ freebsd_repos_url }}`"
-    that:
-      - freebsd_repos_url | match("(?:https?|ftp|file|pkg\+https?):\/\/")
-
-- assert:
-    msg: "freebsd_repos_mirror_type must be one of HTTP, NONE, or SRV: `{{ freebsd_repos_mirror_type }}`"
-    that:
-      - freebsd_repos_mirror_type | upper | match("(?:HTTP|NONE|SRV)$")
-
-- assert:
-    msg: "freebsd_repos_mirror_signature_type must be one of NONE, PUBKEY, or FINGERPRINTS: `{{ freebsd_repos_mirror_signature_type }}`"
-    that:
-      - freebsd_repos_mirror_signature_type | upper | match("(?:NONE|PUBKEY|FINGERPRINTS)$")
-
-- assert:
-    msg: "freebsd_repos_priority must be integer: `{{ freebsd_repos_priority }}`"
-    that:
-      - freebsd_repos_priority is number
-
-- name: Disable default repo
-  template:
-    src: FreeBSD.conf.j2
-    dest: "{{ freebsd_repos_dir }}/FreeBSD.conf"
-    mode: 0644
-  when: freebsd_repos_disable_default_repository
-
 - name: Enable the repo
   template:
     src: repo.conf.j2
     dest: "{{ freebsd_repos_dir }}/{{ freebsd_repos_name }}.conf"
     mode: 0644
+    validate: pkg -vv --config %s | grep -E '^[[:space:]]+reallyenglish:[[:space:]]+{'
+
+- name: Disable default repo
+  # XXX disable the default repo last only when other repo is validated and
+  # created
+  template:
+    src: FreeBSD.conf.j2
+    dest: "{{ freebsd_repos_dir }}/FreeBSD.conf"
+    mode: 0644
+    validate: pkg -vv --config %s
+  when: freebsd_repos_disable_default_repository

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,12 @@
 - assert:
     msg: "freebsd_repos_mirror_type must be one of HTTP, NONE, or SRV: `{{ freebsd_repos_mirror_type }}`"
     that:
-      - freebsd_repos_mirror_type | upper | match("(?:HTTP|NONE|SRV)")
+      - freebsd_repos_mirror_type | upper | match("(?:HTTP|NONE|SRV)$")
 
 - assert:
     msg: "freebsd_repos_mirror_signature_type must be one of NONE, PUBKEY, or FINGERPRINTS: `{{ freebsd_repos_mirror_signature_type }}`"
     that:
-      - freebsd_repos_mirror_signature_type | upper | match("(?:NONE|PUBKEY|FINGERPRINTS)")
+      - freebsd_repos_mirror_signature_type | upper | match("(?:NONE|PUBKEY|FINGERPRINTS)$")
 
 - assert:
     msg: "freebsd_repos_priority must be integer: `{{ freebsd_repos_priority }}`"

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -10,6 +10,8 @@ end
 describe file('/usr/local/etc/pkg/repos/reallyenglish.conf') do
   it { should be_file }
   it { should be_mode 644 }
+  it { should be_owned_by "root" }
+  it { should be_grouped_into "wheel" }
   its(:content) { should match /^reallyenglish: {/ }
   its(:content) { should match /url: "pkg\+http:\/\/10\.3\.build\.reallyenglish.com\/\$\{ABI\}",/ }
   its(:content) { should match /mirror_type: "srv",/ }
@@ -20,5 +22,7 @@ end
 
 describe command('pkg -vv') do
   its(:exit_status) { should eq 0 }
-  its(:stderr) { should match /^$/ }
+  its(:stderr) { should match(/^$/) }
+  its(:stdout) { should match(/^\s+reallyenglish:\s+{/) }
+  its(:stdout) { should_not match(/^\s+FreeBSD:\s+{/) }
 end

--- a/tests/serverspec/enable_default_repo_spec.rb
+++ b/tests/serverspec/enable_default_repo_spec.rb
@@ -8,6 +8,8 @@ end
 describe file('/usr/local/etc/pkg/repos/reallyenglish.conf') do
   it { should be_file }
   it { should be_mode 644 }
+  it { should be_owned_by "root" }
+  it { should be_grouped_into "wheel" }
   its(:content) { should match /^reallyenglish: {/ }
   its(:content) { should match /url: "pkg\+http:\/\/10\.3\.build\.reallyenglish.com\/\$\{ABI\}",/ }
   its(:content) { should match /mirror_type: "srv",/ }
@@ -19,4 +21,6 @@ end
 describe command('pkg -vv') do
   its(:exit_status) { should eq 0 }
   its(:stderr) { should match /^$/ }
+  its(:stdout) { should match(/^\s+reallyenglish:\s+{/) }
+  its(:stdout) { should match(/^\s+FreeBSD:\s+{/) }
 end


### PR DESCRIPTION
and disable default repo only when other repo has been created because, at any moment, at least one repo should be enabled.

fixes #11 